### PR TITLE
Potential fix for code scanning alert no. 22: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -5,6 +5,9 @@ on:
 
 name: check
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/cooljeanius/gcta/security/code-scanning/22](https://github.com/cooljeanius/gcta/security/code-scanning/22)

Add an explicit `permissions` block in `.github/workflows/check.yaml` at the workflow root (top-level) so all jobs inherit least-privilege access unless overridden.  
For this workflow, the minimal required permission is:

- `contents: read` (needed by `actions/checkout`)

Best fix without changing functionality:
- Insert the following between `name: check` and `jobs:`:
  ```yaml
  permissions:
    contents: read
  ```

No imports, methods, or dependencies are needed since this is a YAML workflow configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
